### PR TITLE
Replace deprecated gzip middleware

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,8 +3,8 @@ module github.com/rhardih/serve/v2
 go 1.19
 
 require (
-	github.com/daaku/go.httpgzip v0.0.0-20180202095102-86d27ccd810b
-	github.com/urfave/cli/v2 v2.23.7
+    github.com/urfave/cli/v2 v2.23.7
+    github.com/NYTimes/gziphandler v1.1.1
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -1,9 +1,13 @@
+github.com/NYTimes/gziphandler v1.1.1 h1:ZUDjpQae29j0ryrS0u/B8HZfJBtBQHjqw2rQ2cqUQ3I=
+github.com/NYTimes/gziphandler v1.1.1/go.mod h1:n/CVRwUEOgIxrgPvAQhUUr9oeUtvrhMomdKFjzJNB0c=
 github.com/cpuguy83/go-md2man/v2 v2.0.2 h1:p1EgwI/C7NhT0JmVkwCD2ZBK8j4aeHQX2pMHHBfMQ6w=
 github.com/cpuguy83/go-md2man/v2 v2.0.2/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
-github.com/daaku/go.httpgzip v0.0.0-20180202095102-86d27ccd810b h1:Bv/YpU8I6yk3VSkzWCTG4qjsqs8B7zDyzAuNJPPbtBg=
-github.com/daaku/go.httpgzip v0.0.0-20180202095102-86d27ccd810b/go.mod h1:oS4QGj57ttv8kMrVsLv6T4tUYpcxOWtz9Zgn7WM4LbY=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/russross/blackfriday/v2 v2.1.0 h1:JIOH55/0cWyOuilr9/qlrm0BSXldqnqwMsf35Ld67mk=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/urfave/cli/v2 v2.23.7 h1:YHDQ46s3VghFHFf1DdF+Sh7H4RqhcM+t0TmZRJx4oJY=
 github.com/urfave/cli/v2 v2.23.7/go.mod h1:GHupkWPMM0M/sj1a2b4wUrWBPzazNrIjouW6fmdJLxc=
 github.com/xrash/smetrics v0.0.0-20201216005158-039620a65673 h1:bAn7/zixMGCfxrRTfdpNzjtPYqr8smhKouy9mxVdGPU=

--- a/serve.go
+++ b/serve.go
@@ -9,7 +9,7 @@ import (
 	"os/signal"
 	"syscall"
 
-	httpgzip "github.com/daaku/go.httpgzip"
+	"github.com/NYTimes/gziphandler"
 	"github.com/urfave/cli/v2"
 
 	"crypto/ecdsa"
@@ -239,7 +239,7 @@ func main() {
 			handler := http.FileServer(http.Dir(path))
 
 			if gzip {
-				handler = httpgzip.NewHandler(handler)
+				handler = gziphandler.GzipHandler(handler)
 			}
 
 			if logging {


### PR DESCRIPTION
This commit replaces the daaku/go.httpgzip in favor of of NYTimes/gziphandler
for a gzip middleware as go.httpgzip itself states in its README that it
should not be used anymore.
